### PR TITLE
add portforwarding and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 Simulations, Models, and Visualizations of Portland Fire and Rescue data
 
 ## _IMPORTANT_
-In order for the vagrant box to install correctly, you _must_ download the file 'fire_db' from the shared 
+In order for the vagrant box to install correctly, you _must_ download the file 'fire_db' from the shared
 drive and put it into:
 emergency-response/vagrant/data
 
-If you forget to download the file and try to run 'vagrant up' it will break, and you will have to 
+If you forget to download the file and try to run 'vagrant up' it will break, and you will have to
 'vagrant destroy' before trying to 'vagrant up' again.
 
 ## DB Info:
@@ -19,5 +19,9 @@ username: eruser
 password: fire
 
 
-_BUT_ I set it up so you don't have to enter the password, just hit 'ok' if you are asked for a 
+_BUT_ I set it up so you don't have to enter the password, just hit 'ok' if you are asked for a
 password in pgadmin.
+
+## Port Forwrding:
+
+Port 4545 on guest machine has been forwarded to 4546 on host.

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -24,7 +24,7 @@ Vagrant.configure(2) do |config|
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 80 on the guest machine.
   # config.vm.network "forwarded_port", guest: 80, host: 8080
-  # config.vm.network "forwarded_port", guest: 8888, host: 8888
+  config.vm.network "forwarded_port", guest: 4545, host: 4546
   config.ssh.forward_x11 = true
 
   # Create a private network, which allows host-only access to the machine


### PR DESCRIPTION
Open port 4545 (guest) -> 4546 (host) to enable API access from host machine and add info to readme.